### PR TITLE
Add zsh completion for jcli

### DIFF
--- a/Formula/jcli.rb
+++ b/Formula/jcli.rb
@@ -10,6 +10,10 @@ class Jcli < Formula
     # Install bash completion
     output = Utils.popen_read("#{bin}/jcli completion")
     (bash_completion/"jcli").write output
+    
+    # Install zsh completion
+    output = Utils.popen_read("#{bin}/jcli completion --type zsh")
+    (zsh_completion/"_jcli").write output
 
     prefix.install_metafiles
   end


### PR DESCRIPTION
zsh completion supports since jenkins-zh/jenkins-cli#296

Keep it until jcli v0.0.25 released.